### PR TITLE
solving tensorflow version bug

### DIFF
--- a/model.py
+++ b/model.py
@@ -84,7 +84,7 @@ model.compile(loss = tf.keras.losses.mae,
               metrics = ['mae'])
 
 # Fit the model
-model.fit(X_train, y_train, epochs=100)
+model.fit(tf.expand_dims(X_train, axis=-1), y_train, epochs=100)
 
 
 # Make and plot predictions for model_1


### PR DESCRIPTION
Hello, good afternoon!

First of all, thanks for the video, it helped me a lot.

While testing the code I came across an error due to an update of the tensorflow library that prevents me from `fitting` the model.

The error encountered was this:

```
ValueError: Exception encountered when calling layer "sequential" (type Sequential).
    
    Input 0 of layer "dense" is incompatible with the layer: expected min_ndim=2, found ndim=1. Full shape received: (None,)
    
    Call arguments received:
      • inputs=tf.Tensor(shape=(None,), dtype=int64)
      • training=True
      • mask=None
```

This error was reported in the following issue "[ValueError: Exception encountered when calling layer "sequential" (type Sequential) #256](https://github.com/mrdbourke/tensorflow-deep-learning/discussions/256)" which also was reported in [update](https://github.com/tensorflow/tensorflow/releases/tag/v2.7.0) of tensorflow.

One way to fix this is to update `requirements.txt` to specify a tensorflow version < 2.7.0.

Another way is by updating the code and I took the liberty of doing that in this pull request.

Hugs.